### PR TITLE
Updated icon for Elliptical Add-On on tools

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -303,7 +303,7 @@
                 {
                     "title": "Elliptical Add-On for Google Sheets",
                     "url": "https://workspace.google.com/marketplace/app/elliptical/131612283427",
-                    "image": "https://david-barreto.com/wp-content/uploads/2021/11/big-banner.png",
+                    "image": "https://david-barreto.com/wp-content/uploads/2022/01/elliptical-logo-45px.png",
                     "description": "Custom functions for Google Sheets to fetch data from Axie Infinity",
                     "social": [
                         {


### PR DESCRIPTION
I wasn't aware of the dimensions that the image needed to have and after the merge I could see it was wonky on your website so here's a proper 45x45 png icon that can be used instead.