### PR TITLE
removed dfkwiki.com on defikingdoms

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -17,13 +17,6 @@
                     "authorName": "@Magg | Kingdom.Watch / DFK Discord"
                 },
                 {
-                    "title": "DFK Wiki",
-                    "url": "https://dfkwiki.com/",
-                    "image": "https://dfkwiki.com/assets/img/logo.png",
-                    "description": "DFK Wiki - Heroes, Database, Patch Notes and Tools",
-                    "authorName": "Sarah"
-                },
-                {
                     "title": "DFK Tavern",
                     "url": "https://dfk-tavern.herokuapp.com/",
                     "image": "https://dfk-tavern.herokuapp.com/assets/favicon.ico?m=1638380798.0",


### PR DESCRIPTION
dfkwiki is now down due to Sarah (the maintainer) leaving the community https://twitter.com/satsdart/status/1483431140706951168